### PR TITLE
Add theme provider

### DIFF
--- a/sub-stats/src/App.js
+++ b/sub-stats/src/App.js
@@ -5,16 +5,20 @@ import styled from 'styled-components';
 
 import NavTabs from './components/NavTabs';
 import SummaryContentContainer from './components/SummaryContent/SummaryContentContainer';
+import { MuiThemeProvider } from '@material-ui/core';
+import theme from './theme';
 
 
 function App() {
   const [currentSub, setCurrentSub] = useState({name: "Select a subreddit", description: "Subreddit description goes here!"})
 
   return (
-    <div className="App">
-      <NavTabs></NavTabs>
-      <SummaryContentContainer currentSub={currentSub} setCurrentSub={setCurrentSub}/>
-    </div>
+    <MuiThemeProvider theme={theme}>
+      <div className="App">
+        <NavTabs></NavTabs>
+        <SummaryContentContainer currentSub={currentSub} setCurrentSub={setCurrentSub}/>
+      </div>
+    </MuiThemeProvider>
   );
 }
 

--- a/sub-stats/src/theme.js
+++ b/sub-stats/src/theme.js
@@ -6,10 +6,12 @@ import { Colors } from "./components/Style-Colors";
 const theme = createMuiTheme({
   palette: {
     primary: {
-      main: `${Colors.primary.blue}`
+      main: `${Colors.primary.blue}`,
+      contrastText: `${Colors.neutral.white}`
     },
     secondary: {
-      main: `${Colors.primary.orangered}`
+      main: `${Colors.primary.orangered}`,
+      contrastText: `${Colors.neutral.white}`
     },
     error: {
       main: `${Colors.secondary.yellow}`

--- a/sub-stats/src/theme.js
+++ b/sub-stats/src/theme.js
@@ -1,0 +1,20 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+import { Colors } from "./components/Style-Colors";
+
+
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: `${Colors.primary.blue}`
+    },
+    secondary: {
+      main: `${Colors.primary.orangered}`
+    },
+    error: {
+      main: `${Colors.secondary.yellow}`
+    }
+  }
+});
+
+export default theme;


### PR DESCRIPTION
Add a theme provider so that the default MaterialUI palettes match closer to our intended design (we can still override styles as needed).