### PR TITLE
Display average posts per day and average comments per post data from backend

### DIFF
--- a/sub-stats/src/components/SummaryContent/MiddleInfo/MiddleInfo.js
+++ b/sub-stats/src/components/SummaryContent/MiddleInfo/MiddleInfo.js
@@ -1,8 +1,42 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PostActivity from './PostActivity';
 import { Typography } from '@material-ui/core'
+import axios from 'axios';
+import { apiURL } from '../../../utils/api';
 
 function MiddleInfo (props) {
+    const [avgCommentsPerPost, setAvgCommentsPerPost] = useState(0);
+    const [avgPostsPerDay, setAvgPostsPerDay] = useState(0);
+    const subName = props.currentSub.name;
+
+    useEffect(() => {
+        async function getAveragePosts() {
+            const results = await axios.get(`${apiURL}/posts?start=${props.startDate}&end=${props.endDate}&subreddit=${subName}`);
+            const data = results.data.results;
+            const avg = data.reduce((acc, res) => {
+                return acc + res.data.postsCount;
+            }, 0) / data.length;
+            setAvgPostsPerDay(Math.round(avg));
+        }
+
+        async function getAverageComments() {
+            const results = await axios.get(`${apiURL}/comments?start=${props.startDate}&end=${props.endDate}&subreddit=${subName}`);
+            const data = results.data.results;
+            const avg = data.reduce((acc, res) => {
+                return acc + res.data.averageCommentsPerPost;
+            }, 0) / data.length;
+            setAvgCommentsPerPost(Math.round(avg));
+        }
+
+        if (subName === "" || subName === "Select a subreddit") {
+            setAvgCommentsPerPost(0);
+            setAvgPostsPerDay(0);
+        } else {
+            getAveragePosts();
+            getAverageComments();
+        }
+    }, [props.startDate, props.endDate, subName]);
+
     return (
         <div>
             <Typography variant="h5" color="secondary">When do users post on this subreddit?</Typography>
@@ -10,7 +44,7 @@ function MiddleInfo (props) {
                     currentSub={props.currentSub}
                     startDate={props.startDate}
                     endDate={props.endDate} />
-            <Typography>Users post most frequently between the hours of INSERT HOURS HERE UTC. On average, there are AVERAGE NUMBER posts a day, and each post gets AVERAGE COMMENTS number of comments.</Typography>
+            <Typography>Users post most frequently between the hours of INSERT HOURS HERE UTC. On average, there are {avgPostsPerDay} posts a day, and each post gets {avgCommentsPerPost} number of comments.</Typography>
         </div>
         
     )

--- a/sub-stats/src/components/SummaryContent/MiddleInfo/PostActivity.js
+++ b/sub-stats/src/components/SummaryContent/MiddleInfo/PostActivity.js
@@ -12,14 +12,6 @@ const StyledIframe = styled.iframe`
   border-radius: 1rem;
 `;
 function PostActivity (props) {
-    useEffect(() => {
-        axios.get(`https://yuka-livingston-subreddit.herokuapp.com/posts?start=${props.startDate}&end=${props.endDate}&subreddit=${props.currentSub.name}`)
-            .then(response => {
-                console.log("Response data: ", response);
-            })
-            .catch(error => console.log(error.message))
-    }, [props.currentSub, props.startDate, props.endDate]);
-
     // console.log("This is my current sub: ", props.currentSub.name);
     // console.log("This is my start date: ", props.startDate);
     // console.log("This is my end date: ", props.endDate);


### PR DESCRIPTION
Added the get requests to the backend to get the relevant data and display it in the middle info block under the graph currently, subject to change about where this data will get displayed in the final product.